### PR TITLE
Support for dynamic position

### DIFF
--- a/jquery.mtz.monthpicker.js
+++ b/jquery.mtz.monthpicker.js
@@ -107,6 +107,9 @@
 
         show: function (n) {
             var widget = $('#' + this.data('monthpicker').settings.id);
+            var monthpicker = $('#' + this.data('monthpicker').target.attr("id") + ':eq(0)');
+            widget.css("top", monthpicker.offset().top  + monthpicker.outerHeight());
+            widget.css("left", monthpicker.offset().left);
             widget.show();
             widget.find('select').focus();
             this.trigger('monthpicker-show');


### PR DESCRIPTION
If the element associated with the monthpicker is initially hidden, the widget will be displayed at top: 0 and left: 0. This commit fix the issue
