### PR TITLE
Fixed the auto hiding of the Monthpicker when used with SVG elements.

### DIFF
--- a/jquery.mtz.monthpicker.js
+++ b/jquery.mtz.monthpicker.js
@@ -96,7 +96,7 @@
                     });
 
                     $(document).mousedown(function (e){
-                        if(!e.target.className || e.target.className.indexOf('mtz-monthpicker') < 0){
+                        if(!e.target.className || e.target.className.toString().indexOf('mtz-monthpicker') < 0){
                             $this.monthpicker('hide');
                         }
                     });


### PR DESCRIPTION
Fixed the auto hiding of the monthpicker by adding toString() which was breaking otherwise when used with Highcharts.

Error Fixed: Uncaught TypeError: Object #<SVGAnimatedString> has no method 'indexOf' 

How to reproduce: 
1. Go to http://jsfiddle.net/Lu6Ka/
2. Click in the text box .... monthpicker will appear as expected
3. Click on the chart. Monthpicker should be automatically hidden but it gives aforementioned error.

Please merge this small fix if you find it appropriate.

PS: I loved the Month picker. Its so simple and elegant. Thanks lucianocosta.
