### PR TITLE
Allow date boundaries

### DIFF
--- a/jquery.mtz.monthpicker.js
+++ b/jquery.mtz.monthpicker.js
@@ -1,8 +1,4 @@
 /*
- * ACTIVE PULL REQUESTS HERE:
- * https://github.com/lucianocosta/jquery.mtz.monthpicker/pull/22
- * https://github.com/lucianocosta/jquery.mtz.monthpicker/pull/23  (contains pull 22 as well)
- *
  * jQuery UI Monthpicker
  *
  * @licensed MIT <see below>


### PR DESCRIPTION
(Note I plan to submit this code within the next few days/weeks)

I think it would be nice if I could pass a `startDate` and/or an `endDate` to the settings and have the month picker auto grey out or remove the months that are not selectable. 

Currently to do this I have to add event listeners myself and change the disabledMonths option.  It's a bit tedious to have to keep updating that.  

Deos this seem like a good change to you as well? 
