### PR TITLE
The monthpicker widget should always be inside the page

### DIFF
--- a/jquery.mtz.monthpicker.js
+++ b/jquery.mtz.monthpicker.js
@@ -115,7 +115,13 @@
             var widget = $('#' + this.data('monthpicker').settings.id);
             var monthpicker = $('#' + this.data('monthpicker').target.attr("id") + ':eq(0)');
             widget.css("top", monthpicker.offset().top  + monthpicker.outerHeight());
-            widget.css("left", monthpicker.offset().left);
+            if ($(window).width() > (widget.width() + monthpicker.offset().left) ){
+                widget.css("left", monthpicker.offset().left);
+            }
+            else{
+                widget.css("left", monthpicker.offset().left - widget.width());
+            }
+            
             widget.show();
             widget.find('select').focus();
             this.trigger('monthpicker-show');


### PR DESCRIPTION
If the input field is on the very right of the window, before the monthpicker would only partially fit in the window. Some parts where cut off.

This checks if there is enough space on the right of the input field to display the monthpicker. If not enough space is available, it will move the widget to the left of the input field.
