### PR TITLE
Fix bug, with input fields that have no id

### DIFF
--- a/jquery.mtz.monthpicker.js
+++ b/jquery.mtz.monthpicker.js
@@ -113,7 +113,7 @@
 
         show: function (n) {
             var widget = $('#' + this.data('monthpicker').settings.id);
-            var monthpicker = $('#' + this.data('monthpicker').target.attr("id") + ':eq(0)');
+            var monthpicker = this;
             widget.css("top", monthpicker.offset().top  + monthpicker.outerHeight());
             widget.css("left", monthpicker.offset().left);
             widget.show();


### PR DESCRIPTION
If the target input field has no id the monthpicker fails with a JS-error.

I think I fixed this with patch, but it may need some testing. It is working for me though.
