### PR TITLE
Set initial month and year from value attribute

### DIFF
--- a/jquery.mtz.monthpicker.js
+++ b/jquery.mtz.monthpicker.js
@@ -107,8 +107,8 @@
                                 month = matches[2];
                                 year1 = matches[1];
                             }
-                            month = parseInt(month.replace(/^0/, ''));
-                            year1 = parseInt(year1);
+                            month = parseInt(month, 10);
+                            year1 = parseInt(year1, 10);
                             if (year1 < 50) {
                                 year1 += 2000;
                             } else if (year1 < 100) {


### PR DESCRIPTION
If the month/year input already has a value attribute when the form is loaded and the value is parseable to a valid month and year using settings.pattern, then settings.selectedYear and settings.selectedMonth are set from this value.
