### PR TITLE
Added setDate method.  Fixed parseInt calls to use radix 10.

### DIFF
--- a/jquery.mtz.monthpicker.js
+++ b/jquery.mtz.monthpicker.js
@@ -171,7 +171,7 @@
             settings.disabledMonths = months;
 
             container.find('.mtz-monthpicker-month').each(function () {
-                var m = parseInt($(this).data('month'));
+                var m = parseInt($(this).data('month'), 10);
                 if ($.inArray(m, months) >= 0) {
                     $(this).addClass('ui-state-disabled');
                 } else {
@@ -253,7 +253,7 @@
             }
 
             tbody.find('.mtz-monthpicker-month').on('click', function () {
-                var m = parseInt($(this).data('month'));
+                var m = parseInt($(this).data('month'), 10);
                 if ($.inArray(m, settings.disabledMonths) < 0 ) {
                     settings.selectedYear = $(this).closest('.ui-datepicker').find('.mtz-monthpicker-year').first().val();
                     settings.selectedMonth = $(this).data('month');
@@ -281,6 +281,38 @@
                 return new Date(settings.selectedYear, settings.selectedMonth -1);
             } else {
                 return null;
+            }
+        },
+
+        /**
+         * Sets the selected month and year while preserving all other settings.
+         * @param  {integer} month The one-based month
+         * @param  {integer} year  The full four digit year
+         * @return {void}
+         */
+        setDate: function ( month, year ) {
+            var
+                picker_data = this.data( 'monthpicker' ),
+                displayMonth;
+
+            picker_data.settings.selectedMonthName = picker_data.settings.monthNames[month-1];
+            picker_data.settings.selectedMonth = month;
+            picker_data.settings.selectedYear = year;
+
+            this.data( 'monthpicker', picker_data );
+
+            if(picker_data.settings.pattern.indexOf('mmm') >= 0 ) {
+                displayMonth = picker_data.settings.selectedMonthName;
+            } else if(picker_data.settings.pattern.indexOf('mm') >= 0 && picker_data.settings.selectedMonth < 10) {
+                displayMonth = '0' + month;
+            } else {
+                displayMonth = month;
+            }
+
+            if ( picker_data.settings.pattern.indexOf('y') > picker_data.settings.pattern.indexOf(picker_data.settings.dateSeparator) ) {
+                this.val( displayMonth + picker_data.settings.dateSeparator + year);
+            } else {
+                this.val( year + picker_data.settings.dateSeparator + displayMonth );
             }
         },
 

--- a/jquery.mtz.monthpicker.js
+++ b/jquery.mtz.monthpicker.js
@@ -309,6 +309,10 @@
                 displayMonth = month;
             }
 
+            if(picker_data.settings.pattern.indexOf('yyyy') < 0) {
+                year = year.toString().substr(2,2);
+            } 
+
             if ( picker_data.settings.pattern.indexOf('y') > picker_data.settings.pattern.indexOf(picker_data.settings.dateSeparator) ) {
                 this.val( displayMonth + picker_data.settings.dateSeparator + year);
             } else {


### PR DESCRIPTION
I fixed the two parseInt calls to explicitly specify base 10.  This fixes a problem if the data-month attribute of the input element is set to "09".

I added a setDate method that takes a one-based integer month and year to be used on pages that reset the selected month/year.  Ajax pages that get new data from the server need to be able to easily update the month picker that's already on the page.

The setValue method can also be used to set the selected month/year, but that has a few drawbacks:
1. You have to keep the complete settings object outside of the month picker instead of just passing the settings at page creation.
2. You have to set the selectedMonthName if you're using the 'mmm' format.  If the month picker is localized, requiring the selected month name is then dependent on tracking what localization you're in and the localized month names which defeats otherwise simple localization efforts.
3. The setValue method calls this.change() which will trigger other JS that is watching for the user to change the month picker.  This is usually undesired behavior if you're programmatically pushing a new month/year into the month picker.
